### PR TITLE
AX-680: remove fields no longer supported by the db

### DIFF
--- a/src/main/kotlin/io/athletex/model/nfl/NFLPlayer.kt
+++ b/src/main/kotlin/io/athletex/model/nfl/NFLPlayer.kt
@@ -20,10 +20,6 @@ data class NFLPlayer(
     val OffensiveSnapsPlayed: Double,
     val DefensiveSnapsPlayed: Double,
     val price: Double,
-    val Touchdowns: Double,
-    val PassingInterceptions: Double,
-    val FumblesLost: Double,
-    val RushingTouchdowns: Double,
     val timestamp: String,
 ): Player() {
     companion object {
@@ -42,10 +38,6 @@ data class NFLPlayer(
                 OffensiveSnapsPlayed = row.getDouble(NFLPlayers.offensiveSnapsPlayed.name),
                 DefensiveSnapsPlayed = row.getDouble(NFLPlayers.defensiveSnapsPlayed.name),
                 price = row.getDouble(NFLPlayers.price.name),
-                Touchdowns = row.getDouble(NFLPlayers.touchdowns.name),
-                PassingInterceptions = row.getDouble(NFLPlayers.passingInterceptions.name),
-                FumblesLost = row.getDouble(NFLPlayers.fumblesLost.name),
-                RushingTouchdowns = row.getDouble(NFLPlayers.rushingTouchdowns.name),
                 timestamp = row.getString(NFLPlayers.timestamp.name),
             )
         }

--- a/src/main/kotlin/io/athletex/model/nfl/NFLPlayerStats.kt
+++ b/src/main/kotlin/io/athletex/model/nfl/NFLPlayerStats.kt
@@ -39,10 +39,6 @@ data class NFLPlayerStats(
                         rushingYards = row.getDouble(NFLPlayers.rushingYards.name),
                         OffensiveSnapsPlayed = row.getDouble(NFLPlayers.offensiveSnapsPlayed.name),
                         DefensiveSnapsPlayed = row.getDouble(NFLPlayers.defensiveSnapsPlayed.name),
-                        Touchdowns = row.getDouble(NFLPlayers.touchdowns.name),
-                        PassingInterceptions = row.getDouble(NFLPlayers.passingInterceptions.name),
-                        FumblesLost = row.getDouble(NFLPlayers.fumblesLost.name),
-                        RushingTouchdowns = row.getDouble(NFLPlayers.rushingTouchdowns.name),
                         price = row.getDouble(NFLPlayers.price.name),
                         timestamp = row.getString(NFLPlayers.timestamp.name).toString(),
                     )
@@ -62,10 +58,6 @@ data class NFLPlayerStats(
         val rushingYards: Double,
         val OffensiveSnapsPlayed: Double,
         val DefensiveSnapsPlayed: Double,
-        val Touchdowns: Double,
-        val PassingInterceptions: Double,
-        val FumblesLost: Double,
-        val RushingTouchdowns: Double,
         val price: Double,
         val timestamp: String,
     )


### PR DESCRIPTION
> Touchdowns,
> PassingInterceptions,
> FumblesLost,
> RushingTouchdowns: 

These fields have all been removed by @user2745 in the db according to the new pricing formula